### PR TITLE
feat: implement secure window on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # react-native-secure-window
 
-Enabling or disabling secure window on Android
+## Android
 
+Enabling or disabling secure window on Android
 If you aren't aware what this package is about check [this](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE) link
+
+## iOS
+
+The latest version adds support for iOS. \
+iOS does not have a secure window feature like Android, but here we chose to add a blurred view. \
+We hook into the event [`UIApplicationWillResignActiveNotification`](https://developer.apple.com/documentation/uikit/uiapplicationwillresignactivenotification) to enabled the blurred view and hook into the event [`UIApplicationDidBecomeActiveNotification`](https://developer.apple.com/documentation/uikit/uiapplicationdidbecomeactivenotification) to disable it again.
 
 ## Installation
 
@@ -20,15 +27,12 @@ yarn add react-native-secure-window
 import SecureWindow from "react-native-secure-window";
 
 //Can be used imperatively
-
 SecureWindow.changeSecureWindow(true);
 ```
 
 ## Contributing
 
 See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the repository and the development workflow.
-
-There is no official way to secure screen in iOS. Any hacky PR's are welcome
 
 ## License
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -231,7 +231,7 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
   - React-jsinspector (0.62.2)
-  - react-native-secure-window (0.1.0):
+  - react-native-secure-window (0.2.2):
     - React
   - React-RCTActionSheet (0.62.2):
     - React-Core/RCTActionSheetHeaders (= 0.62.2)
@@ -427,7 +427,7 @@ SPEC CHECKSUMS:
   React-jsi: b6dc94a6a12ff98e8877287a0b7620d365201161
   React-jsiexecutor: 1540d1c01bb493ae3124ed83351b1b6a155db7da
   React-jsinspector: 512e560d0e985d0e8c479a54a4e5c147a9c83493
-  react-native-secure-window: f74727ae93e9037a073a284df41d362a9cb589e9
+  react-native-secure-window: 086659f78b677b6ec641daa1aa876bbe235a1237
   React-RCTActionSheet: f41ea8a811aac770e0cc6e0ad6b270c644ea8b7c
   React-RCTAnimation: 49ab98b1c1ff4445148b72a3d61554138565bad0
   React-RCTBlob: a332773f0ebc413a0ce85942a55b064471587a71
@@ -443,4 +443,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 376c51106aa1deefccdf0acee2c852ffedade85e
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.2

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,19 +3,22 @@ import { StyleSheet, View, Text, Button } from 'react-native';
 import SecureWindow from 'react-native-secure-window';
 
 export default function App() {
-  const [isScreenWindowSecured, setScreenWindowSecured] = React.useState<
-    boolean | undefined
-  >();
+  const [
+    isScreenWindowSecured,
+    setScreenWindowSecured,
+  ] = React.useState<boolean>(false);
 
   React.useEffect(() => {
-    SecureWindow.changeSecureWindow(true);
-  }, []);
+    SecureWindow.changeSecureWindow(isScreenWindowSecured);
+  }, [isScreenWindowSecured]);
 
   return (
     <View style={styles.container}>
-      <Text>isScreenWindowsSecured - {isScreenWindowSecured}</Text>
+      <Text>
+        isScreenWindowsSecured - {isScreenWindowSecured ? 'Yes' : 'No'}
+      </Text>
       <Button
-        title={`Toggle Screen Window state ${isScreenWindowSecured}`}
+        title="Toggle Screen Window state"
         onPress={() => {
           setScreenWindowSecured(
             (prevIsScreenWindowSecured) => !prevIsScreenWindowSecured

--- a/ios/SecureWindow.h
+++ b/ios/SecureWindow.h
@@ -1,7 +1,9 @@
+#import <UIKit/UIKit.h>
 #import <React/RCTBridgeModule.h>
 
 @interface SecureWindow : NSObject <RCTBridgeModule>
 
-    @property (nonatomic) BOOL *isSecureWindowActive;
+    @property (nonatomic, nullable) BOOL *isSecureWindowActive;
+    @property (nonatomic, strong, nullable) UIVisualEffectView *blurEffectView;
 
 @end

--- a/ios/SecureWindow.m
+++ b/ios/SecureWindow.m
@@ -1,14 +1,73 @@
 #import "SecureWindow.h"
-#import <React/RCTLog.h>
+#import "RCTUtils.h"
 
 @implementation SecureWindow
 
-RCT_EXPORT_MODULE(SecureWindow)
+RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(changeSecureWindow: (BOOL *) canChangeSecureWindow)
+- (instancetype)init
 {
-    self.isSecureWindowActive = canChangeSecureWindow;
-    RCTLogInfo(@"Yet to implement full functionality %i", self.isSecureWindowActive);
+    if (self = [super init]) {
+        [self startObserving];
+    }
+    
+    return self;
+}
+
+- (void)dealloc
+{
+    [self stopObserving];
+}
+
+RCT_EXPORT_METHOD(changeSecureWindow: (BOOL *)canChangeSecureWindow) {
+    _isSecureWindowActive = canChangeSecureWindow;
+}
+
+- (void)startObserving
+{
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleAddSecurity)
+                                                 name:UIApplicationWillResignActiveNotification
+                                               object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleRemoveSecurity)
+                                                 name:UIApplicationDidBecomeActiveNotification
+                                               object:nil];
+}
+
+- (void)stopObserving
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)handleAddSecurity {
+    if (!_isSecureWindowActive) {
+        return;
+    }
+    
+    UIWindow *window = RCTSharedApplication().delegate.window;
+    UIBlurEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleLight];
+    self.blurEffectView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
+    [self.blurEffectView setFrame:window.bounds];
+    self.blurEffectView.alpha = 0;
+    [window addSubview:self.blurEffectView];
+    [window bringSubviewToFront:self.blurEffectView];
+    [UIView animateWithDuration:0.5 animations:^{
+        self.blurEffectView.alpha = 1;
+    }];
+}
+
+- (void)handleRemoveSecurity {
+    [UIView animateWithDuration:0.5 animations:^{
+        self.blurEffectView.alpha = 0;
+    } completion:^(BOOL finished) {
+        [self.blurEffectView removeFromSuperview];
+    }];
+}
+
++ (BOOL)requiresMainQueueSetup {
+    return NO;
 }
 
 @end


### PR DESCRIPTION
This pull request introduces the secure window functionality for iOS. 
We do not have the same possibilities as with Android, for that I use a blur view. This will not show the app content, and we have a secure window on iOS as well.

I've also changed the example code to show the current state better.

https://user-images.githubusercontent.com/1516413/136234276-babedafd-4ebe-488d-bc9b-9fd8e10af5ac.MP4



